### PR TITLE
DOI badge and link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Power of Python in GIS
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11203958.svg)](https://doi.org/10.5281/zenodo.11203958) 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11202762.svg)](https://doi.org/10.5281/zenodo.11202762) 
 [![Static Badge](https://img.shields.io/badge/Python-black?style=flat-square&logo=python&logoColor=blue&labelColor=gray&color=yellow)](https://www.python.org/)
 [![Static Badge](https://img.shields.io/badge/jupyter-blue?style=flat-square&logo=jupyter&logoColor=white&labelColor=gray&color=orange)](https://jupyter.org/)
 [![Static Badge](https://img.shields.io/badge/MIT%20License%20-blue?style=flat-square)](https://github.com/UtrechtUniversity/src-jupyter-workshop-template/blob/main/LICENSE)
@@ -30,7 +30,7 @@ The participants of this workshop are typically provided with a notebook environ
 
 ## Repository materials
 
-- The workshop materials can be found in the  <a href="https://github.com/UtrechtUniversity/gis-python-power/tree/main/workshop-materials">**wokshop-materials folder**</a>. It contains the jupyter notebooks as well as the data used for the workshop.
+- The workshop materials can be found in the  <a href="https://github.com/UtrechtUniversity/gis-python-power/tree/main/workshop_materials">**wokshop-materials folder**</a>. It contains the jupyter notebooks as well as the data used for the workshop.
 - The folder <a href="https://github.com/UtrechtUniversity/gis-python-power/tree/main/playbooks">**playbooks**</a> is exclusively dedicated for automated transfer of the course materials to the digital workspaces on SURF Research Cloud.
 - The `environment.yml` file describes the packages that are required to run the notebooks. The file is used to create a python kernel on SURF Research Cloud that has all the packages installed.
 - The `.github` folder contains a GitHub Actions workflow that will automatically update the zipped `workshop-materials.zip` whenever there are changes to the `workshop-materials` folder.


### PR DESCRIPTION
DOI badge now links to the most up to date version of the Zenodo repository.  
Fixed the workshop material folder link.   